### PR TITLE
forwards old links from file_tree to correct url

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -306,3 +306,28 @@
 		return $result;
 	}
 	
+  /*
+   * forwards old links to correct content
+   */
+  function file_tools_forward_old_link($hook, $type, $return, $params) {
+    
+    $result = $return;
+    $parts = $return['segments'];
+    
+    switch ($parts[0]) {
+      case 'list':
+        default:
+          $owner = get_entity($parts[1]);
+          if (!$owner) {
+            return $result; // 404
+          }
+          $url = elgg_get_site_url() . 'file/owner/' . $owner->username;
+          if (elgg_instanceof($owner, 'group', '', 'ElggGroup')) {
+            $url = elgg_get_site_url() . 'file/group/' . $owner->guid . '/all';
+          }
+          
+          forward($url);
+          return FALSE;
+          break;
+    }
+  }

--- a/start.php
+++ b/start.php
@@ -63,6 +63,7 @@
 		elgg_register_plugin_hook_handler("permissions_check:metadata", "object", "file_tools_can_edit_metadata_hook");
 // 		elgg_register_plugin_hook_handler("access:collections:write", "all", "file_tools_write_acl_plugin_hook", 550);
 		elgg_register_plugin_hook_handler("route", "file", "file_tools_file_route_hook");
+		elgg_register_plugin_hook_handler("route", "file_tree", "file_tools_forward_old_link");
 		elgg_register_plugin_hook_handler("register", "menu:title", "file_tools_title_menu_register_hook");
 		elgg_register_plugin_hook_handler("widget_url", "widget_manager", "file_tools_widget_url_hook");
 		


### PR DESCRIPTION
When upgrading a site from 1.7 that was using file_tree there are probably bookmarked links to a person/groups folders.  Additionally there may be existing external bookmarks to such pages.  This PR forwards those old links to the correct location in file_tools.
