### PR TITLE
fixes folder structure when zip contains empty folders

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -601,7 +601,13 @@
 		$zip_entry_name = zip_entry_name($zip_entry);
 		$filename = basename($zip_entry_name);
 		
-		$zip_base = str_replace($filename, "", $zip_entry_name);
+		if (substr($zip_entry_name, -1) != '/') {
+            $zip_base = str_replace($filename, "", $zip_entry_name);
+        }
+        else {
+            $zip_base = $zip_entry_name;
+        }
+		
 		$zdir = substr($zip_base, 0, -1);
 		
 		if (!empty($zdir)) {


### PR DESCRIPTION
If an uploaded zip file contains empty directories, these directories are not turned into folders on the elgg system.  Additionally an empty folder with no title is created.
This fixes that behavior such that the final folder structure on the elgg system exactly matches that of the zip file.
