### PR TITLE
remove superfluous sanitize_string

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -730,7 +730,7 @@
 		            
 				$parent = $parent_guid;
 				foreach($folder_array as $folder) {
-					$folder = sanitize_string(utf8_encode($folder));
+					$folder = utf8_encode($folder);
 					
 					if($entity = file_tools_check_foldertitle_exists($folder, $container_guid, $parent)) {
 						$parent = $entity->getGUID();


### PR DESCRIPTION
This causes problems when zipped folder names have special characters such as a single quote which end up getting double-sanitized.

Because file_tools_check_foldertitle_exists sanitizes the title for the query as well you end up searching for "Matt\\'s files" and it never matches, therefore all files in folders with a quote end up in the root folder.
