### PR TITLE
Folder write access can now be altered with a plugin hook

### DIFF
--- a/views/default/file_tools/list/tree.php
+++ b/views/default/file_tools/list/tree.php
@@ -22,7 +22,9 @@ $body .= elgg_view_menu("file_tools_folder_sidebar_tree", array(
 ));
 $body .= "</div>";
 
-if ($page_owner->canEdit() || ($page_owner instanceof ElggGroup && $page_owner->isMember() && $page_owner->file_tools_structure_management_enable != "no")) {
+$user_guid = elgg_get_logged_in_user_guid();
+
+if ($page_owner->canWriteToContainer($user_guid, 'object', FILE_TOOLS_SUBTYPE) && $page_owner->file_tools_structure_management_enable != "no") {
 	elgg_load_js("lightbox");
 	elgg_load_css("lightbox");
 


### PR DESCRIPTION
This allows plugins to alter the folder write permission by using the
[container_permissions_check, object] hook. The plugins will be able
to decide the permission based on container, user and the object
subtype (file_tools folder).