### PR TITLE
fixed: double request on load main folder

### DIFF
--- a/views/default/js/file_tools/tree.js
+++ b/views/default/js/file_tools/tree.js
@@ -177,10 +177,6 @@ define(function(require) {
 	 *
 	 */
 	$(function() {
-		if (window.location.hash.substring(1) == '') {
-			file_tools.load_folder(0);
-		}
-
 		$(window).hashchange(function(){
 			file_tools.load_folder(window.location.hash.substring(1));
 		});


### PR DESCRIPTION
Already been taken care off in the ready.jstree listener, which also handles loading sub-folders. See [here](https://github.com/Wouter0100/file_tools/blob/8f603688bc71166223bde175330acdaed6942591/views/default/js/file_tools/tree.js#L51).